### PR TITLE
Add state based invariant checks

### DIFF
--- a/CQRSGui/CQRSGui.csproj
+++ b/CQRSGui/CQRSGui.csproj
@@ -151,6 +151,7 @@
     <Content Include="Scripts\MicrosoftMvcValidation.debug.js" />
     <Content Include="Scripts\MicrosoftMvcValidation.js" />
     <Content Include="Views\Home\Add.aspx" />
+    <Content Include="Views\Home\ChangeMaxQty.aspx" />
     <Content Include="Views\Home\ChangeName.aspx" />
     <Content Include="Views\Home\CheckIn.aspx" />
     <Content Include="Views\Home\Details.aspx" />

--- a/CQRSGui/Controllers/HomeController.cs
+++ b/CQRSGui/Controllers/HomeController.cs
@@ -95,5 +95,18 @@ namespace CQRSGui.Controllers
             _bus.Send(new RemoveItemsFromInventory(id, number, version));
             return RedirectToAction("Index");
         }
+
+        public ActionResult ChangeMaxQty(Guid id)
+        {
+            ViewData.Model = _readmodel.GetInventoryItemDetails(id);
+            return View();
+        }
+
+        [HttpPost]
+        public ActionResult ChangeMaxQty(Guid id, int number, int version)
+        {
+            _bus.Send(new ChangeMaxQty(id, number, version));
+            return RedirectToAction("Index");
+        }
     }
 }

--- a/CQRSGui/Global.asax.cs
+++ b/CQRSGui/Global.asax.cs
@@ -41,12 +41,14 @@ namespace CQRSGui
             bus.RegisterHandler<DeactivateInventoryItem>(commands.Handle);
             bus.RegisterHandler<RemoveItemsFromInventory>(commands.Handle);
             bus.RegisterHandler<RenameInventoryItem>(commands.Handle);
+            bus.RegisterHandler<ChangeMaxQty>(commands.Handle);
             var detail = new InventoryItemDetailView();
             bus.RegisterHandler<InventoryItemCreated>(detail.Handle);
             bus.RegisterHandler<InventoryItemDeactivated>(detail.Handle);
             bus.RegisterHandler<InventoryItemRenamed>(detail.Handle);
             bus.RegisterHandler<ItemsCheckedInToInventory>(detail.Handle);
             bus.RegisterHandler<ItemsRemovedFromInventory>(detail.Handle);
+            bus.RegisterHandler<MaxQtyChanged>(detail.Handle);
             var list = new InventoryListView();
             bus.RegisterHandler<InventoryItemCreated>(list.Handle);
             bus.RegisterHandler<InventoryItemRenamed>(list.Handle);

--- a/CQRSGui/Views/Home/ChangeMaxQty.aspx
+++ b/CQRSGui/Views/Home/ChangeMaxQty.aspx
@@ -1,0 +1,13 @@
+<%@ Page Title="" Language="C#" Inherits="System.Web.Mvc.ViewPage<SimpleCQRS.InventoryItemDetailsDto>" MasterPageFile="~/Views/Shared/Site.Master" %>
+<asp:Content runat="server" ID="Title" ContentPlaceHolderID="TitleContent"></asp:Content>
+<asp:Content runat="server" ID="Main" ContentPlaceHolderID="MainContent">
+        <% using (Html.BeginForm())
+       {%>
+        <%: Html.Hidden("Id",Model.Id) %>
+        <%: Html.Hidden("Version",Model.Version) %>
+        Number:<%: Html.TextBox("Number") %><br />
+        <button name="submit">Submit</button>
+
+    <%
+       }%>
+</asp:Content>

--- a/CQRSGui/Views/Home/Details.aspx
+++ b/CQRSGui/Views/Home/Details.aspx
@@ -4,10 +4,12 @@
 <h2>Details:</h2>
 Id: <%:Model.Id%><br />
 Name: <%:Model.Name%><br />
+MaxQty: <%:Model.MaxQty%><br />
 Count: <%: Model.CurrentCount %><br /><br />
 
 <%: Html.ActionLink("Rename","ChangeName", new{Id=Model.Id}) %><br />
 <%: Html.ActionLink("Deactivate","Deactivate",new{Id=Model.Id, Version=Model.Version}) %><br />
 <%: Html.ActionLink("Check in","CheckIn", new{Id=Model.Id}) %><br />
-<%: Html.ActionLink("Remove","Remove", new{Id=Model.Id,Version=Model.Version}) %>
+<%: Html.ActionLink("Remove","Remove", new{Id=Model.Id,Version=Model.Version}) %><br />
+<%: Html.ActionLink("Change Max Qty","ChangeMaxQty", new{Id=Model.Id,Version=Model.Version}) %>
 </asp:Content>

--- a/SimpleCQRS/CommandHandlers.cs
+++ b/SimpleCQRS/CommandHandlers.cs
@@ -44,5 +44,12 @@ namespace SimpleCQRS
             item.ChangeName(message.NewName);
             _repository.Save(item, message.OriginalVersion);
         }
+
+        public void Handle(ChangeMaxQty message)
+        {
+            var item = _repository.GetById(message.InventoryItemId);
+            item.ChangeMaxQty(message.NewMaxQty);
+            _repository.Save(item, message.OriginalVersion);
+        }
     }
 }

--- a/SimpleCQRS/Commands.cs
+++ b/SimpleCQRS/Commands.cs
@@ -64,4 +64,17 @@ namespace SimpleCQRS
             OriginalVersion = originalVersion;
         }
     }
+    public class ChangeMaxQty : Command
+    {
+        public Guid InventoryItemId;
+        public readonly int NewMaxQty;
+        public readonly int OriginalVersion;
+
+        public ChangeMaxQty(Guid inventoryItemId, int newMaxQty, int originalVersion)
+        {
+            InventoryItemId = inventoryItemId;
+            NewMaxQty = newMaxQty;
+            OriginalVersion = originalVersion;
+        }
+    }
 }

--- a/SimpleCQRS/Domain.cs
+++ b/SimpleCQRS/Domain.cs
@@ -49,17 +49,18 @@ namespace SimpleCQRS
             ApplyChange(new ItemsRemovedFromInventory(_id, count));
         }
 
-
         public void CheckIn(int count)
         {
             if(count <= 0) throw new InvalidOperationException("must have a count greater than 0 to add to inventory");
             if(AvailableQty + count > MaxQty) throw new InvalidOperationException("Checked in count will exceed Max Qty");
             ApplyChange(new ItemsCheckedInToInventory(_id, count));
         }
-        public void ChangeMaxQty(int count)
+
+        public void ChangeMaxQty(int newMaxQty)
         {
-            if (count <= 0) throw new InvalidOperationException("Max Qty must be larger than 0");
-            ApplyChange(new ItemsCheckedInToInventory(_id, count));
+            if (newMaxQty <= 0) throw new InvalidOperationException("New Max Qty must be larger than 0");
+            if (newMaxQty < AvailableQty) throw new InvalidOperationException("New Max Qty cannot be less than Available Qty");
+            ApplyChange(new ItemsCheckedInToInventory(_id, newMaxQty));
         }
 
         public void Deactivate()

--- a/SimpleCQRS/Domain.cs
+++ b/SimpleCQRS/Domain.cs
@@ -8,6 +8,9 @@ namespace SimpleCQRS
         private bool _activated;
         private Guid _id;
 
+        public int AvailableQty { get; set; }
+        public int MaxQty { get; set; } = 5;
+
         private void Apply(InventoryItemCreated e)
         {
             _id = e.Id;
@@ -17,6 +20,21 @@ namespace SimpleCQRS
         private void Apply(InventoryItemDeactivated e)
         {
             _activated = false;
+        }
+
+        private void Apply(MaxQtyChanged e)
+        {
+            MaxQty = e.NewMaxQty;
+        }
+
+        private void Apply(ItemsCheckedInToInventory e)
+        {
+            AvailableQty += e.Count;
+        }
+
+        private void Apply(ItemsRemovedFromInventory e)
+        {
+            AvailableQty -= e.Count;
         }
 
         public void ChangeName(string newName)

--- a/SimpleCQRS/Domain.cs
+++ b/SimpleCQRS/Domain.cs
@@ -80,7 +80,7 @@ namespace SimpleCQRS
 
         public InventoryItem(Guid id, string name)
         {
-            ApplyChange(new InventoryItemCreated(id, name));
+            ApplyChange(new InventoryItemCreated(id, name, MaxQty));
         }
     }
 

--- a/SimpleCQRS/Domain.cs
+++ b/SimpleCQRS/Domain.cs
@@ -56,6 +56,11 @@ namespace SimpleCQRS
             if(AvailableQty + count > MaxQty) throw new InvalidOperationException("Checked in count will exceed Max Qty");
             ApplyChange(new ItemsCheckedInToInventory(_id, count));
         }
+        public void ChangeMaxQty(int count)
+        {
+            if (count <= 0) throw new InvalidOperationException("Max Qty must be larger than 0");
+            ApplyChange(new ItemsCheckedInToInventory(_id, count));
+        }
 
         public void Deactivate()
         {

--- a/SimpleCQRS/Domain.cs
+++ b/SimpleCQRS/Domain.cs
@@ -53,6 +53,7 @@ namespace SimpleCQRS
         public void CheckIn(int count)
         {
             if(count <= 0) throw new InvalidOperationException("must have a count greater than 0 to add to inventory");
+            if(AvailableQty + count > MaxQty) throw new InvalidOperationException("Checked in count will exceed Max Qty");
             ApplyChange(new ItemsCheckedInToInventory(_id, count));
         }
 

--- a/SimpleCQRS/Events.cs
+++ b/SimpleCQRS/Events.cs
@@ -18,9 +18,13 @@ namespace SimpleCQRS
     public class InventoryItemCreated : Event {
         public readonly Guid Id;
         public readonly string Name;
-        public InventoryItemCreated(Guid id, string name) {
+        public readonly int MaxQty;
+
+        public InventoryItemCreated(Guid id, string name, int maxQty)
+        {
             Id = id;
             Name = name;
+            MaxQty = maxQty;
         }
     }
 
@@ -55,6 +59,17 @@ namespace SimpleCQRS
         public ItemsRemovedFromInventory(Guid id, int count) {
             Id = id;
             Count = count;
+        }
+    }
+    public class MaxQtyChanged : Event
+    {
+        public Guid Id;
+        public readonly int NewMaxQty;
+
+        public MaxQtyChanged(Guid id, int newMaxQty)
+        {
+            Id = id;
+            NewMaxQty = newMaxQty;
         }
     }
 }

--- a/SimpleCQRS/ReadModel.cs
+++ b/SimpleCQRS/ReadModel.cs
@@ -100,6 +100,12 @@ namespace SimpleCQRS
         {
             FakeDatabase.details.Remove(message.Id);
         }
+
+        public void Handle(MaxQtyChanged message)
+        {
+            InventoryItemDetailsDto d = GetDetailsItem(message.Id);
+            d.MaxQty = message.NewMaxQty;
+        }
     }
 
     public class ReadModelFacade : IReadModelFacade

--- a/SimpleCQRS/ReadModel.cs
+++ b/SimpleCQRS/ReadModel.cs
@@ -13,13 +13,15 @@ namespace SimpleCQRS
     {
         public Guid Id;
         public string Name;
+        public int MaxQty;
         public int CurrentCount;
         public int Version;
 
-        public InventoryItemDetailsDto(Guid id, string name, int currentCount, int version)
+        public InventoryItemDetailsDto(Guid id, string name, int maxQty, int currentCount, int version)
         {
             Id = id;
             Name = name;
+            MaxQty = maxQty;
             CurrentCount = currentCount;
             Version = version;
         }
@@ -60,7 +62,7 @@ namespace SimpleCQRS
     {
         public void Handle(InventoryItemCreated message)
         {
-            FakeDatabase.details.Add(message.Id, new InventoryItemDetailsDto(message.Id, message.Name, 0,0));
+            FakeDatabase.details.Add(message.Id, new InventoryItemDetailsDto(message.Id, message.Name, message.MaxQty, 0,0));
         }
 
         public void Handle(InventoryItemRenamed message)

--- a/SimpleCQRS/ReadModel.cs
+++ b/SimpleCQRS/ReadModel.cs
@@ -85,14 +85,14 @@ namespace SimpleCQRS
         public void Handle(ItemsRemovedFromInventory message)
         {
             InventoryItemDetailsDto d = GetDetailsItem(message.Id);
-            d.CurrentCount -= message.Count;
+            d.CurrentCount = message.Count;
             d.Version = message.Version;
         }
 
         public void Handle(ItemsCheckedInToInventory message)
         {
             InventoryItemDetailsDto d = GetDetailsItem(message.Id);
-            d.CurrentCount += message.Count;
+            d.CurrentCount = message.Count;
             d.Version = message.Version;
         }
 


### PR DESCRIPTION
I added an example of a state-based business invariant check as in issue #15 . It adds a 'hydrated' MaxQty property that Check Ins can be compared against. It also made sense to move the ephemeral 'count' property that didn't really exist in the abstration but was just passed around as an argument and was actually changed in the read model. It seemed to make much more sense to put it in the Inventory Aggregate as an actual property.